### PR TITLE
Include the publish S3 bucket in SQS notifications.

### DIFF
--- a/main.py
+++ b/main.py
@@ -159,7 +159,7 @@ def copy_object(event: CopyEvent):
         f"Copying s3://{event.embargo_bucket}/{event.key} to s3://{event.publish_bucket}/{event.key}"
     )
 
-    GB = 1024 ** 3
+    GB = 1024**3
     config = boto3.s3.transfer.TransferConfig(
         multipart_threshold=5 * GB, use_threads=False
     )

--- a/terraform/state-machine.json
+++ b/terraform/state-machine.json
@@ -51,6 +51,7 @@
           "organization_id.$": "$.organization_id",
           "dataset_id.$": "$.dataset_id",
           "version.$": "$.version",
+          "s3_bucket.$": "$.s3_bucket",
           "status": "PUBLISH_SUCCEEDED",
           "success": true
         }
@@ -68,6 +69,7 @@
           "organization_id.$": "$.organization_id",
           "dataset_id.$": "$.dataset_id",
           "version.$": "$.version",
+          "s3_bucket.$": "$.s3_bucket",
           "status": "RELEASE_FAILED",
           "success": false,
           "error.$": "$.error.Cause"


### PR DESCRIPTION
The receiver of our SQS notifications now expect an s3_bucket field that shows the bucket to which the dataset was published. So this PR adds that field.