### PR TITLE
Handle both custom publish and embargo buckets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     environment:
       ENVIRONMENT: local
       SERVICE_NAME: discover-release
-      EMBARGO_BUCKET: test-embargo-bucket-use1
       AWS_ACCESS_KEY_ID: xxxx
       AWS_SECRET_ACCESS_KEY: yyyy
       AWS_DEFAULT_REGION: 'us-east-1'

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -12,7 +12,6 @@ data "template_file" "task_definition" {
     image_tag                    = var.image_tag
     service_name                 = var.service_name
 
-    embargo_bucket = data.terraform_remote_state.platform_infrastructure.outputs.discover_embargo_bucket_id
   }
 }
 

--- a/terraform/state-machine.json
+++ b/terraform/state-machine.json
@@ -27,7 +27,10 @@
               "Value.$": "$.s3_key"
             }, {
               "Name": "PUBLISH_BUCKET",
-              "Value.$": "$.s3_bucket"
+              "Value.$": "$.publish_bucket"
+            }, {
+              "Name": "EMBARGO_BUCKET",
+              "Value.$": "$.embargo_bucket"
             }]
           }]
         }
@@ -54,7 +57,8 @@
           "organization_id.$": "$.organization_id",
           "dataset_id.$": "$.dataset_id",
           "version.$": "$.version",
-          "s3_bucket.$": "$.s3_bucket",
+          "publish_bucket.$": "$.publish_bucket",
+          "embargo_bucket.$": "$.embargo_bucket",
           "status": "PUBLISH_SUCCEEDED",
           "success": true
         }
@@ -72,7 +76,8 @@
           "organization_id.$": "$.organization_id",
           "dataset_id.$": "$.dataset_id",
           "version.$": "$.version",
-          "s3_bucket.$": "$.s3_bucket",
+          "publish_bucket.$": "$.publish_bucket",
+          "embargo_bucket.$": "$.embargo_bucket",
           "status": "RELEASE_FAILED",
           "success": false,
           "error.$": "$.error.Cause"

--- a/terraform/task-definition.json
+++ b/terraform/task-definition.json
@@ -7,8 +7,7 @@
     },
     "environment": [
       { "name" : "ENVIRONMENT", "value": "${environment_name}" },
-      { "name" : "SERVICE_NAME", "value": "${service_name}" },
-      { "name" : "EMBARGO_BUCKET", "value": "${embargo_bucket}" }
+      { "name" : "SERVICE_NAME", "value": "${service_name}" }
     ],
     "logConfiguration": {
       "logDriver": "awslogs",

--- a/test.py
+++ b/test.py
@@ -4,9 +4,10 @@ import time
 import boto3
 import pytest
 
-from main import EMBARGO_BUCKET, LOCALSTACK_URL, release_files
+from main import LOCALSTACK_URL, release_files
 
 PUBLISH_BUCKET = "test-publish-bucket"
+EMBARGO_BUCKET = "test-embargo-bucket"
 
 # This key corresponds to assets belonging to a dataset in the embargo bucket
 # that needs to be released to the public bucket.
@@ -63,7 +64,7 @@ def test_copy_files_to_publish_bucket(publish_bucket, embargo_bucket):
     assert sorted(s3_keys(publish_bucket)) == []
     assert sorted(s3_keys(embargo_bucket)) == sorted([s3_key_to_move, s3_key_to_leave])
 
-    release_files(S3_PREFIX_TO_MOVE, PUBLISH_BUCKET)
+    release_files(S3_PREFIX_TO_MOVE, EMBARGO_BUCKET, PUBLISH_BUCKET)
 
     # VERIFY RESULTS
     assert sorted(s3_keys(publish_bucket)) == [s3_key_to_move]
@@ -80,7 +81,7 @@ def test_handle_key_without_trailing_slash(publish_bucket, embargo_bucket):
     assert sorted(s3_keys(publish_bucket)) == []
     assert sorted(s3_keys(embargo_bucket)) == sorted([s3_key_to_move, s3_key_to_leave])
 
-    release_files(S3_PREFIX_TO_MOVE, PUBLISH_BUCKET)
+    release_files(S3_PREFIX_TO_MOVE, EMBARGO_BUCKET, PUBLISH_BUCKET)
 
     # VERIFY RESULTS
     assert sorted(s3_keys(publish_bucket)) == [s3_key_to_move]
@@ -102,7 +103,7 @@ def test_copy_files_pagination(publish_bucket, embargo_bucket):
     assert sorted(s3_keys(publish_bucket)) == []
     assert sorted(s3_keys(embargo_bucket)) == sorted(s3_keys_to_move + s3_keys_to_leave)
 
-    release_files(S3_PREFIX_TO_MOVE, PUBLISH_BUCKET)
+    release_files(S3_PREFIX_TO_MOVE, EMBARGO_BUCKET, PUBLISH_BUCKET)
 
     # VERIFY RESULTS
     assert sorted(s3_keys(publish_bucket)) == sorted(s3_keys_to_move)


### PR DESCRIPTION
The names of the embargo and publish buckets must both come from the triggering event per release since they both can be custom for a given organization.