### PR TITLE
Fix Discover Release - add S3 permissions

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -122,6 +122,7 @@ data "aws_iam_policy_document" "ecs_task_iam_policy_document" {
 
     actions = [
       "s3:GetObject",
+      "s3:GetObjectAttributes",
       "s3:DeleteObject",
       "s3:ListBucket",
     ]
@@ -141,6 +142,7 @@ data "aws_iam_policy_document" "ecs_task_iam_policy_document" {
     actions = [
       "s3:GetObject",
       "s3:GetObjectVersion",
+      "s3:GetObjectVersionAttributes",
       "s3:DeleteObject",
       "s3:DeleteObjectVersion",
       "s3:ListBucket",
@@ -158,7 +160,12 @@ data "aws_iam_policy_document" "ecs_task_iam_policy_document" {
   statement {
     sid     = "S3DiscoverBucket"
     effect  = "Allow"
-    actions = ["s3:PutObject"]
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectAttributes",
+      "s3:ListBucket",
+      "s3:PutObject"
+    ]
 
     resources = [
       data.terraform_remote_state.platform_infrastructure.outputs.discover_publish_bucket_arn,
@@ -171,7 +178,14 @@ data "aws_iam_policy_document" "ecs_task_iam_policy_document" {
   statement {
     sid     = "S3Discover50Bucket"
     effect  = "Allow"
-    actions = ["s3:PutObject"]
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:GetObjectVersionAttributes",
+      "s3:ListBucket",
+      "s3:ListBucketVersions",
+      "s3:PutObject"
+    ]
 
     resources = [
       data.terraform_remote_state.platform_infrastructure.outputs.discover_publish50_bucket_arn,


### PR DESCRIPTION
expand permissions on S3 buckets to permit getting object attributes