### PR TITLE
Add permissions for rejoin buckets

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -156,6 +156,10 @@ data "aws_iam_policy_document" "ecs_task_iam_policy_document" {
       "${data.terraform_remote_state.platform_infrastructure.outputs.discover_embargo50_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo50_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_embargo50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_embargo50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn}/*",
     ]
   }
 
@@ -197,6 +201,10 @@ data "aws_iam_policy_document" "ecs_task_iam_policy_document" {
       "${data.terraform_remote_state.platform_infrastructure.outputs.discover_publish50_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_publish50_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_publish50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn}/*",
     ]
   }
 }


### PR DESCRIPTION
Adds the aws-rejoin publish and embargo buckets to IAM policies.