### PR TITLE
Add S3 bucket ARNs to IAM policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea/
+.DS_Store

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -206,7 +206,7 @@ data "aws_iam_policy_document" "ecs_task_iam_policy_document" {
       data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_publish50_bucket_arn,
-      "${data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_publish50_bucket_arn}/*"
+      "${data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_publish50_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.awsod_edots_publish50_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.awsod_edots_publish50_bucket_arn}/*",
     ]

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -207,6 +207,8 @@ data "aws_iam_policy_document" "ecs_task_iam_policy_document" {
       "${data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_publish50_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_publish50_bucket_arn}/*"
+      data.terraform_remote_state.platform_infrastructure.outputs.awsod_edots_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.awsod_edots_publish50_bucket_arn}/*",
     ]
   }
 }


### PR DESCRIPTION
Added .DS_Store to .gitignore to prevent committing macOS system files. Updated the ECS task IAM policy document in terraform/iam.tf to include ARNs for the awsod_edots_publish50 S3 bucket, allowing access to this new resource.