### PR TITLE
Add *ObjectTagging permissions

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -144,6 +144,7 @@ data "aws_iam_policy_document" "ecs_task_iam_policy_document" {
       "s3:GetObjectAttributes",
       "s3:GetObjectVersion",
       "s3:GetObjectVersionAttributes",
+      "s3:GetObjectTagging",
       "s3:DeleteObject",
       "s3:DeleteObjectVersion",
       "s3:ListBucket",
@@ -192,6 +193,7 @@ data "aws_iam_policy_document" "ecs_task_iam_policy_document" {
       "s3:ListBucket",
       "s3:ListBucketVersions",
       "s3:PutObject",
+      "s3:PutObjectTagging",
       "s3:DeleteObject",
       "s3:DeleteObjectVersion"
     ]


### PR DESCRIPTION
User uploaded files are tagged in S3 with dataset and organization node ids. In order to copy these files from the embargo to the publish bucket the ECS task needs to be able to read and write the tags. PR adds those permissions.

### non-prod Terraform plan showing the change already temporarily made in the AWS Console
```
Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # module.service_module.aws_ecs_task_definition.ecs_task_definition has changed
  ~ resource "aws_ecs_task_definition" "ecs_task_definition" {
        id                       = "dev-discover-release-use1"
      + tags                     = {}
        # (13 unchanged attributes hidden)
    }

  # module.service_module.aws_iam_policy.ecs_task_iam_policy has changed
  ~ resource "aws_iam_policy" "ecs_task_iam_policy" {
        id        = "arn:aws:iam::941165240011:policy/dev-discover-release-ecs-task-policy-use1"
        name      = "dev-discover-release-ecs-task-policy-use1"
      ~ policy    = jsonencode(
          ~ {
              ~ Statement = [
                    {
                        Action   = [
                            "s3:ListBucket",
                            "s3:GetObjectAttributes",
                            "s3:GetObject",
                            "s3:DeleteObject",
                        ]
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:s3:::sparc-dev-embargo-use1/*",
                            "arn:aws:s3:::sparc-dev-embargo-use1",
                            "arn:aws:s3:::pennsieve-dev-discover-embargo-use1/*",
                            "arn:aws:s3:::pennsieve-dev-discover-embargo-use1",
                        ]
                        Sid      = "S3EmbargoBucket"
                    },
                  ~ {
                      ~ Action   = [
                            # (6 unchanged elements hidden)
                            "s3:GetObject",
                          + "s3:GetObjectTagging",
                            "s3:DeleteObjectVersion",
                            # (1 unchanged element hidden)
                        ]
                        # (3 unchanged elements hidden)
                    },
                    {
                        Action   = [
                            "s3:PutObject",
                            "s3:ListBucket",
                            "s3:GetObjectAttributes",
                            "s3:GetObject",
                        ]
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:s3:::sparc-dev-discover-use1/*",
                            "arn:aws:s3:::sparc-dev-discover-use1",
                            "arn:aws:s3:::pennsieve-dev-discover-publish-use1/*",
                            "arn:aws:s3:::pennsieve-dev-discover-publish-use1",
                        ]
                        Sid      = "S3DiscoverBucket"
                    },
                  ~ {
                      ~ Action   = [
                            "s3:PutObject",
                          + "s3:PutObjectTagging",
                            "s3:ListBucketVersions",
                            # (7 unchanged elements hidden)
                        ]
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        tags      = {}
        # (4 unchanged attributes hidden)
    }

  # module.service_module.aws_iam_role.ecs_execution_iam_role has changed
  ~ resource "aws_iam_role" "ecs_execution_iam_role" {
        id                    = "dev-discover-release-ecs-execution-role-use1"
        name                  = "dev-discover-release-ecs-execution-role-use1"
      ~ role_last_used        = [
          ~ {
              ~ last_used_date = "2025-07-31T00:00:55Z" -> "2026-04-16T18:26:57Z"
                # (1 unchanged element hidden)
            },
        ]
        tags                  = {}
        # (9 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # module.service_module.aws_iam_role.ecs_task_iam_role has changed
  ~ resource "aws_iam_role" "ecs_task_iam_role" {
        id                    = "dev-discover-release-ecs-task-role-use1"
        name                  = "dev-discover-release-ecs-task-role-use1"
      ~ role_last_used        = [
          ~ {
              ~ last_used_date = "2025-07-31T00:01:01Z" -> "2026-04-16T18:26:55Z"
                # (1 unchanged element hidden)
            },
        ]
        tags                  = {}
        # (9 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # module.service_module.aws_iam_role.state_machine_iam_role has changed
  ~ resource "aws_iam_role" "state_machine_iam_role" {
        id                    = "dev-discover-release-state-machine-role-use1"
        name                  = "dev-discover-release-state-machine-role-use1"
      ~ role_last_used        = [
          ~ {
              ~ last_used_date = "2025-07-31T00:01:26Z" -> "2026-04-16T18:27:22Z"
                # (1 unchanged element hidden)
            },
        ]
        tags                  = {}
        # (9 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or respond to these changes.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

No changes. Your infrastructure matches the configuration.
```