### PR TITLE
868ja00qy rewrite manifest.json on release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ COPY requirements-test.txt ./
 
 RUN python3 -m pip install -r requirements-test.txt
 
-COPY main.py test.py test.txt ./
+COPY main.py test.py ./

--- a/main.py
+++ b/main.py
@@ -495,7 +495,7 @@ def release_manifest(
     result_by_path = {}
     for result in copy_results:
         if result.target_key.startswith(s3_key_prefix):
-            relative_path = result.target_key[len(s3_key_prefix):]
+            relative_path = result.target_key[len(s3_key_prefix) :]
             result_by_path[relative_path] = result
 
     # Update s3VersionId and sha256 on each file entry. The manifest's own

--- a/main.py
+++ b/main.py
@@ -452,8 +452,7 @@ def release_manifest(
     The manifest's own entry in `files` is left without a fresh
     `s3VersionId` or `sha256` (a manifest cannot reference its own
     post-upload values), but its `size` IS patched to match the byte count
-    of the rewritten manifest (converged iteratively because writing the
-    size into the manifest changes the byte count).
+    of the rewritten manifest.
 
     Raises FileNotFoundError if the manifest is missing under `manifest_key`,
     or if the manifest references files that were not copied (i.e. are not
@@ -473,11 +472,8 @@ def release_manifest(
         )
     except ClientError as e:
         if e.response.get("Error", {}).get("Code") in ("NoSuchKey", "404", "NotFound"):
-            log.error(
-                f"manifest.json not found at s3://{embargo_bucket}/{manifest_key}; aborting release"
-            )
             raise FileNotFoundError(
-                f"required manifest.json not found at s3://{embargo_bucket}/{manifest_key}"
+                f"required {MANIFEST_FILENAME} not found at s3://{embargo_bucket}/{manifest_key}"
             ) from e
         raise
 
@@ -498,26 +494,29 @@ def release_manifest(
     updated_version_ids = 0
     updated_sha256s = 0
     missing_paths = []
-    manifest_self_entry = None
     for file_entry in manifest.get("files", []):
-        path = file_entry.get("path")
+        path = get_file_entry_path_or_fail(file_entry)
         if path == MANIFEST_FILENAME:
-            manifest_self_entry = file_entry
-            continue
-        if not path:
+            # the manifest's own entry does not have S3 versionId or sha256
             continue
         result = result_by_path.get(path)
         if result is None:
             missing_paths.append(path)
             continue
 
-        if result.target_version_id and result.target_version_id != "none":
-            file_entry["s3VersionId"] = result.target_version_id
-            updated_version_ids += 1
+        # get_object_attributes uses "none" as a sentinel for missing values
+        if not result.target_version_id or result.target_version_id == "none":
+            raise ValueError(
+                f"copy result for {path} missing required target_version_id: {result}"
+            )
+
+        file_entry["s3VersionId"] = result.target_version_id
+        updated_version_ids += 1
 
         # Only rewrite sha256 on entries that already have one. Adding it
         # to entries that didn't have it would change the manifest's
         # schema for those files, which is out of scope here.
+        # get_object_attributes uses "none" as a sentinel for missing values.
         if "sha256" in file_entry:
             if result.target_sha256 and result.target_sha256 != "none":
                 file_entry["sha256"] = result.target_sha256
@@ -526,19 +525,14 @@ def release_manifest(
     if missing_paths:
         preview = missing_paths[:5]
         suffix = "..." if len(missing_paths) > 5 else ""
-        log.error(
-            f"manifest.json references {len(missing_paths)} file(s) that are not present "
-            f"in the embargo bucket under {s3_key_prefix}: {preview}{suffix}; aborting release"
-        )
         raise FileNotFoundError(
-            f"manifest.json references {len(missing_paths)} file(s) that are not present "
+            f"{MANIFEST_FILENAME} references {len(missing_paths)} file(s) that are not present "
             f"in the embargo bucket under {s3_key_prefix}: {preview}{suffix}"
         )
 
     # Patch the manifest's own `size` so it matches the byte count of the
     # rewritten manifest.
-    if manifest_self_entry is not None:
-        set_manifest_size(manifest_self_entry, manifest)
+    set_manifest_size(manifest)
 
     modified_body = serialize_manifest(manifest)
 
@@ -577,11 +571,28 @@ def release_manifest(
     )
 
 
+def get_file_entry_path_or_fail(file_entry):
+    path = file_entry.get("path")
+    if not path:
+        raise ValueError(
+            f"manifest.json file entry missing required 'path' field: {file_entry}"
+        )
+    return path
+
+
 def serialize_manifest(manifest):
     return json.dumps(manifest, indent=2).encode("utf-8")
 
 
-def set_manifest_size(manifest_self_entry, manifest):
+def set_manifest_size(manifest):
+    manifest_self_entry = None
+    for file_entry in manifest.get("files", []):
+        if get_file_entry_path_or_fail(file_entry) == MANIFEST_FILENAME:
+            manifest_self_entry = file_entry
+            break
+    if manifest_self_entry is None:
+        raise ValueError(f"{MANIFEST_FILENAME} file is missing entry for self")
+
     manifest_self_entry["size"] = 0
     # subtract one byte for length of 0 character
     manifest_len_no_size = len(serialize_manifest(manifest)) - 1

--- a/main.py
+++ b/main.py
@@ -6,6 +6,13 @@ discover-release
 Fargate task to move files from the embargo bucket to the public Discover bucket.
 Once all files are moved, the files are deleted from the embargo bucket.
 
+Before the dataset manifest (manifest.json) is copied to the publish bucket, it
+is rewritten so that each file entry's `s3VersionId` (and `sha256`, where
+present) points at the values assigned by the publish bucket. The manifest's
+own `size` is also patched to reflect the rewritten byte count. The release is
+aborted if the manifest is missing so that embargo files can be left in place
+for inspection and retry.
+
 """
 
 import dataclasses
@@ -20,6 +27,7 @@ from typing import Any
 
 import boto3
 import structlog
+from botocore.exceptions import ClientError
 
 ENVIRONMENT = os.environ["ENVIRONMENT"]
 SERVICE_NAME = os.environ["SERVICE_NAME"]
@@ -43,6 +51,17 @@ EmbargoResultRetentionDays = 180
 EMBARGO_RESULT_RETENTION_DAYS = int(
     os.environ.get("EMBARGO_RESULT_RETENTION_DAYS", EmbargoResultRetentionDays)
 )
+
+# The dataset manifest is copied with modifications: its `files[].s3VersionId`
+# (and `files[].sha256`, where present) entries are rewritten with the values
+# assigned by the publish bucket after each file is copied, and its own
+# `size` entry is patched to match the rewritten byte count.
+MANIFEST_FILENAME = "manifest.json"
+
+# Maximum iterations to converge on the manifest's self-referenced `size`
+# field. Each pass changes the integer representation of `size` by at most
+# one digit, so this converges in 2-3 iterations in practice.
+MANIFEST_SIZE_MAX_ITERATIONS = 10
 
 
 class EnhancedJSONEncoder(json.JSONEncoder):
@@ -274,13 +293,13 @@ class FileCopier:
         return CopyResult(
             source_bucket=source_attributes.bucket,
             source_key=source_attributes.key,
-            source_size=str(source_attributes.size),
+            source_size=source_attributes.size,
             source_version_id=source_attributes.version_id,
             source_etag=source_attributes.etag,
             source_sha256=source_attributes.sha256,
             target_bucket=target_attributes.bucket,
             target_key=target_attributes.key,
-            target_size=str(target_attributes.size),
+            target_size=target_attributes.size,
             target_version_id=target_attributes.version_id,
             target_etag=target_attributes.etag,
             target_sha256=target_attributes.sha256,
@@ -342,20 +361,43 @@ def release_files(request_id, s3_key_prefix, embargo_bucket, publish_bucket):
 
     log.info(f"boto3 version: {boto3.__version__}")
 
+    # Full S3 key of the dataset manifest, e.g. "10/manifest.json".
+    manifest_key = f"{s3_key_prefix}{MANIFEST_FILENAME}"
+
     copy_results = []
     try:
         log.info("Starting thread pool")
 
         with Pool(processes=4) as pool:
+            # Copy every file EXCEPT the dataset manifest. The manifest is
+            # handled separately below so its s3VersionId/sha256 references
+            # can be rewritten with the values assigned by the publish bucket.
             for copy_result in pool.imap_unordered(
                 copy_object,
                 (
                     CopyEvent(embargo_bucket, publish_bucket, key, log)
                     for key in iter_keys(embargo_bucket, s3_key_prefix)
+                    if key != manifest_key
                 ),
             ):
                 copy_results.append(copy_result)
 
+            # Rewrite manifest.json with the new version IDs / checksums and
+            # upload the modified bytes to the publish bucket. If the manifest
+            # is missing this raises FileNotFoundError, which propagates out
+            # of the `try` BEFORE the delete pool runs, leaving embargo
+            # untouched so the release can be inspected and retried.
+            manifest_result = release_manifest(
+                embargo_bucket=embargo_bucket,
+                publish_bucket=publish_bucket,
+                manifest_key=manifest_key,
+                s3_key_prefix=s3_key_prefix,
+                copy_results=copy_results,
+                log=log,
+            )
+            copy_results.append(manifest_result)
+
+            # Delete everything (including the original manifest) from embargo.
             for _ in pool.imap_unordered(
                 delete_object,
                 (
@@ -396,6 +438,161 @@ def release_files(request_id, s3_key_prefix, embargo_bucket, publish_bucket):
         Body=json_data,
         RequestPayer="requester",
         Expires=expiration,
+    )
+
+
+def release_manifest(
+    embargo_bucket, publish_bucket, manifest_key, s3_key_prefix, copy_results, log
+):
+    """
+    Download manifest.json from the embargo bucket and rewrite each file
+    entry so that:
+
+      * `s3VersionId` reflects the version ID assigned by the publish bucket
+        for that file (taken from the `copy_results` produced by the copy
+        pool).
+      * `sha256` (when already present on the entry) reflects the SHA256
+        checksum reported by the publish bucket for that file.
+
+    The manifest's own entry in `files` is left without a fresh
+    `s3VersionId` or `sha256` (a manifest cannot reference its own
+    post-upload values), but its `size` IS patched to match the byte count
+    of the rewritten manifest (converged iteratively because writing the
+    size into the manifest changes the byte count).
+
+    Raises FileNotFoundError if the manifest is missing under `manifest_key`,
+    or if the manifest references files that were not copied (i.e. are not
+    present in the embargo bucket). Either condition aborts the release
+    without deleting anything from embargo so the operator can fix the
+    dataset and retry.
+
+    Returns a CopyResult describing the manifest upload.
+    """
+    s3 = local.s3_client
+
+    try:
+        response = s3.get_object(
+            Bucket=embargo_bucket,
+            Key=manifest_key,
+            RequestPayer="requester",
+        )
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") in ("NoSuchKey", "404", "NotFound"):
+            log.error(
+                f"manifest.json not found at s3://{embargo_bucket}/{manifest_key}; aborting release"
+            )
+            raise FileNotFoundError(
+                f"required manifest.json not found at s3://{embargo_bucket}/{manifest_key}"
+            ) from e
+        raise
+
+    manifest = json.loads(response["Body"].read())
+
+    # Manifest file paths are relative to the dataset root (e.g.
+    # "files/sin_wave.edf") whereas S3 keys include the dataset prefix
+    # (e.g. "10/files/sin_wave.edf"). Strip the prefix to build a
+    # `relative_path -> CopyResult` map.
+    result_by_path = {}
+    for result in copy_results:
+        if result.target_key.startswith(s3_key_prefix):
+            relative_path = result.target_key[len(s3_key_prefix):]
+            result_by_path[relative_path] = result
+
+    # Update s3VersionId and sha256 on each file entry. The manifest's own
+    # entry is skipped here; its `size` is patched separately below.
+    updated_version_ids = 0
+    updated_sha256s = 0
+    missing_paths = []
+    manifest_self_entry = None
+    for file_entry in manifest.get("files", []):
+        path = file_entry.get("path")
+        if path == MANIFEST_FILENAME:
+            manifest_self_entry = file_entry
+            continue
+        if not path:
+            continue
+        result = result_by_path.get(path)
+        if result is None:
+            missing_paths.append(path)
+            continue
+
+        if result.target_version_id and result.target_version_id != "none":
+            file_entry["s3VersionId"] = result.target_version_id
+            updated_version_ids += 1
+
+        # Only rewrite sha256 on entries that already have one. Adding it
+        # to entries that didn't have it would change the manifest's
+        # schema for those files, which is out of scope here.
+        if "sha256" in file_entry:
+            if result.target_sha256 and result.target_sha256 != "none":
+                file_entry["sha256"] = result.target_sha256
+                updated_sha256s += 1
+
+    if missing_paths:
+        preview = missing_paths[:5]
+        suffix = "..." if len(missing_paths) > 5 else ""
+        log.error(
+            f"manifest.json references {len(missing_paths)} file(s) that are not present "
+            f"in the embargo bucket under {s3_key_prefix}: {preview}{suffix}; aborting release"
+        )
+        raise FileNotFoundError(
+            f"manifest.json references {len(missing_paths)} file(s) that are not present "
+            f"in the embargo bucket under {s3_key_prefix}: {preview}{suffix}"
+        )
+
+    # Patch the manifest's own `size` so it matches the byte count of the
+    # rewritten manifest. Setting `size` changes the byte count, so iterate
+    # to a fixed point. The integer representation of `size` grows by at
+    # most one digit per iteration, so this converges in 2-3 passes.
+    if manifest_self_entry is not None:
+        manifest_self_entry["size"] = 0
+        modified_body = json.dumps(manifest, indent=2).encode("utf-8")
+        for _ in range(MANIFEST_SIZE_MAX_ITERATIONS):
+            actual_size = len(modified_body)
+            if manifest_self_entry["size"] == actual_size:
+                break
+            manifest_self_entry["size"] = actual_size
+            modified_body = json.dumps(manifest, indent=2).encode("utf-8")
+        else:
+            log.warning(
+                f"manifest.json size did not converge after {MANIFEST_SIZE_MAX_ITERATIONS} "
+                f"iterations: reported {manifest_self_entry['size']} vs actual {len(modified_body)}"
+            )
+    else:
+        modified_body = json.dumps(manifest, indent=2).encode("utf-8")
+
+    log.info(
+        f"uploading modified manifest.json to s3://{publish_bucket}/{manifest_key} "
+        f"(rewrote {updated_version_ids} s3VersionId, {updated_sha256s} sha256, "
+        f"{len(modified_body)} bytes)"
+    )
+
+    s3.put_object(
+        Bucket=publish_bucket,
+        Key=manifest_key,
+        Body=modified_body,
+        ChecksumAlgorithm=CHECKSUM_ALGORITHM,
+        RequestPayer="requester",
+    )
+
+    # Capture attributes for the release-results summary so the manifest
+    # appears alongside every other file.
+    source_attrs = local.file_copier.get_object_attributes(embargo_bucket, manifest_key)
+    target_attrs = local.file_copier.get_object_attributes(publish_bucket, manifest_key)
+
+    return CopyResult(
+        source_bucket=source_attrs.bucket,
+        source_key=source_attrs.key,
+        source_size=source_attrs.size,
+        source_version_id=source_attrs.version_id,
+        source_etag=source_attrs.etag,
+        source_sha256=source_attrs.sha256,
+        target_bucket=target_attrs.bucket,
+        target_key=target_attrs.key,
+        target_size=target_attrs.size,
+        target_version_id=target_attrs.version_id,
+        target_etag=target_attrs.etag,
+        target_sha256=target_attrs.sha256,
     )
 
 

--- a/main.py
+++ b/main.py
@@ -58,11 +58,6 @@ EMBARGO_RESULT_RETENTION_DAYS = int(
 # `size` entry is patched to match the rewritten byte count.
 MANIFEST_FILENAME = "manifest.json"
 
-# Maximum iterations to converge on the manifest's self-referenced `size`
-# field. Each pass changes the integer representation of `size` by at most
-# one digit, so this converges in 2-3 iterations in practice.
-MANIFEST_SIZE_MAX_ITERATIONS = 10
-
 
 class EnhancedJSONEncoder(json.JSONEncoder):
     def default(self, o):
@@ -198,7 +193,7 @@ class FileCopier:
         return response
 
     def byte_range(self, offset, size):
-        return f"bytes={offset}-{offset+size-1}"
+        return f"bytes={offset}-{offset + size - 1}"
 
     def generate_part_list(self, object_size, max_part_size):
         parts = []
@@ -541,25 +536,11 @@ def release_manifest(
         )
 
     # Patch the manifest's own `size` so it matches the byte count of the
-    # rewritten manifest. Setting `size` changes the byte count, so iterate
-    # to a fixed point. The integer representation of `size` grows by at
-    # most one digit per iteration, so this converges in 2-3 passes.
+    # rewritten manifest.
     if manifest_self_entry is not None:
-        manifest_self_entry["size"] = 0
-        modified_body = json.dumps(manifest, indent=2).encode("utf-8")
-        for _ in range(MANIFEST_SIZE_MAX_ITERATIONS):
-            actual_size = len(modified_body)
-            if manifest_self_entry["size"] == actual_size:
-                break
-            manifest_self_entry["size"] = actual_size
-            modified_body = json.dumps(manifest, indent=2).encode("utf-8")
-        else:
-            log.warning(
-                f"manifest.json size did not converge after {MANIFEST_SIZE_MAX_ITERATIONS} "
-                f"iterations: reported {manifest_self_entry['size']} vs actual {len(modified_body)}"
-            )
-    else:
-        modified_body = json.dumps(manifest, indent=2).encode("utf-8")
+        set_manifest_size(manifest_self_entry, manifest)
+
+    modified_body = serialize_manifest(manifest)
 
     log.info(
         f"uploading modified manifest.json to s3://{publish_bucket}/{manifest_key} "
@@ -594,6 +575,22 @@ def release_manifest(
         target_etag=target_attrs.etag,
         target_sha256=target_attrs.sha256,
     )
+
+
+def serialize_manifest(manifest):
+    return json.dumps(manifest, indent=2).encode("utf-8")
+
+
+def set_manifest_size(manifest_self_entry, manifest):
+    manifest_self_entry["size"] = 0
+    # subtract one byte for length of 0 character
+    manifest_len_no_size = len(serialize_manifest(manifest)) - 1
+    len_of_size = len(str(manifest_len_no_size))
+    size = manifest_len_no_size + len_of_size
+    # needs adjustment if we are at a power of 10
+    if len(str(size)) > len_of_size:
+        size += 1
+    manifest_self_entry["size"] = size
 
 
 def iter_keys(bucket, prefix):

--- a/test.py
+++ b/test.py
@@ -238,9 +238,9 @@ def test_manifest_is_rewritten_with_publish_bucket_values(
         ), f"{rel_path} still has the stale embargo sha256"
 
     for rel_path in paths_without_sha256:
-        assert "sha256" not in by_path[rel_path], (
-            f"{rel_path} unexpectedly gained a sha256 field"
-        )
+        assert (
+            "sha256" not in by_path[rel_path]
+        ), f"{rel_path} unexpectedly gained a sha256 field"
 
     # Fields that the rewrite is NOT supposed to touch (name, path, size,
     # fileType, sourcePackageId, and anything else the manifest happens to
@@ -254,9 +254,9 @@ def test_manifest_is_rewritten_with_publish_bucket_values(
         updated = by_path[rel_path]
         for field in pass_through_fields:
             if field in original:
-                assert field in updated, (
-                    f"{rel_path}: pass-through field {field!r} was dropped"
-                )
+                assert (
+                    field in updated
+                ), f"{rel_path}: pass-through field {field!r} was dropped"
                 assert updated[field] == original[field], (
                     f"{rel_path}: pass-through field {field!r} changed from "
                     f"{original[field]!r} to {updated[field]!r}"
@@ -343,9 +343,7 @@ def upload_manifest(embargo_bucket, prefix, file_paths, *, with_sha256=()):
         files.append(entry)
     manifest = {"pennsieveDatasetId": 1234, "version": 1, "files": files}
     key = os.path.join(prefix, MANIFEST_RELATIVE_PATH)
-    embargo_bucket.put_object(
-        Key=key, Body=json.dumps(manifest).encode("utf-8")
-    )
+    embargo_bucket.put_object(Key=key, Body=json.dumps(manifest).encode("utf-8"))
     return key, manifest
 
 

--- a/test.py
+++ b/test.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 import boto3
 import pytest
 
-from main import LOCALSTACK_URL, release_files
+from main import LOCALSTACK_URL, release_files, serialize_manifest, set_manifest_size
 
 PUBLISH_BUCKET = "test-publish-bucket"
 EMBARGO_BUCKET = "test-embargo-bucket"
@@ -311,8 +311,59 @@ def test_release_aborts_when_manifest_references_missing_file(
     assert present_key in s3_keys(embargo_bucket)
     assert manifest_key in s3_keys(embargo_bucket)
 
-def test_set_manifest_size_edge_case():
-    pass
+
+def test_set_manifest_size_matches_serialized_length_across_range():
+    """
+    manifest.json carries a self-referencing `size`: the byte count of the
+    file is itself a value inside the file, so writing a longer number
+    changes the byte count it's supposed to describe. set_manifest_size
+    handles this by estimating the size-digit count and adding 1 when the
+    estimate is too low.
+
+    The estimate is too low precisely when the size value crosses a power
+    of 10. For example, if everything except the size occupies 997 bytes,
+    the naive estimate is 997 + len("997") = 1000 -- but "1000" is FOUR
+    digits, not three, so the manifest is really 997 + 4 = 1001 bytes.
+    Without the +1, set_manifest_size would record 1000 in a 1001-byte
+    file.
+
+    Sweeping a range of manifest sizes that spans the 10^3-byte boundary
+    exercises both the adjustment case and the non-adjustment cases on
+    either side of it. For every size, the recorded value must match the
+    actual serialized byte count.
+    """
+
+    def _make_padded_manifest(padding_length):
+        """
+        Build a minimal manifest with a single self-entry plus a padding field
+        of the requested character length. Padding goes on a sibling top-level
+        field, not the self-entry, so the self-entry's own structure (and
+        therefore which fields set_manifest_size will and won't touch) is the
+        same regardless of how big we make the surrounding manifest.
+        """
+        manifest_json_entry = {
+            "name": "manifest.json",
+            "path": MANIFEST_RELATIVE_PATH,
+            "size": 0,
+            "fileType": "Json",
+        }
+        return {
+            "padding": "x" * padding_length,
+            "files": [manifest_json_entry],
+        }
+
+    for padding_len in range(0, 1100):
+        manifest = _make_padded_manifest(padding_len)
+        self_entry = manifest["files"][0]
+
+        set_manifest_size(self_entry, manifest)
+
+        actual = len(serialize_manifest(manifest))
+        assert self_entry["size"] == actual, (
+            f"padding_len={padding_len}: set_manifest_size recorded "
+            f"size={self_entry['size']} but actual serialized length is {actual}"
+        )
+
 
 def upload_manifest(embargo_bucket, prefix, file_paths, *, with_sha256=()):
     """

--- a/test.py
+++ b/test.py
@@ -1,3 +1,4 @@
+import json
 import os
 import time
 import uuid
@@ -10,16 +11,17 @@ from main import LOCALSTACK_URL, release_files
 PUBLISH_BUCKET = "test-publish-bucket"
 EMBARGO_BUCKET = "test-embargo-bucket"
 
-# This key corresponds to assets belonging to a dataset in the embargo bucket
-# that needs to be released to the public bucket.
-S3_PREFIX_TO_MOVE = "1/10/"
+# Prefix of the dataset being released. The current convention is
+# `<dataset-id>/`.
+S3_PREFIX_TO_MOVE = "10/"
 
-# This key corresponds to assets belonging to a dataset version
-# that should remain untouched by this lambda function
-S3_PREFIX_TO_LEAVE = "1/100/"
+# Prefix of an unrelated dataset that should remain untouched by the release.
+S3_PREFIX_TO_LEAVE = "100/"
 
 # This is a dummy file
 FILENAME = "test.txt"
+
+MANIFEST_RELATIVE_PATH = "manifest.json"
 
 s3_resource = boto3.resource("s3", endpoint_url=LOCALSTACK_URL)
 
@@ -47,12 +49,12 @@ def setup():
 
 @pytest.fixture(scope="function")
 def publish_bucket(setup):
-    return setup_bucket(PUBLISH_BUCKET)
+    return setup_bucket(PUBLISH_BUCKET, versioned=True)
 
 
 @pytest.fixture(scope="function")
 def embargo_bucket(setup):
-    return setup_bucket(EMBARGO_BUCKET)
+    return setup_bucket(EMBARGO_BUCKET, versioned=False)
 
 
 def test_copy_files_to_publish_bucket(publish_bucket, embargo_bucket):
@@ -61,9 +63,12 @@ def test_copy_files_to_publish_bucket(publish_bucket, embargo_bucket):
 
     embargo_bucket.upload_file(Filename=FILENAME, Key=s3_key_to_move)
     embargo_bucket.upload_file(Filename=FILENAME, Key=s3_key_to_leave)
+    manifest_key, _ = upload_manifest(embargo_bucket, S3_PREFIX_TO_MOVE, [FILENAME])
 
     assert sorted(s3_keys(publish_bucket)) == []
-    assert sorted(s3_keys(embargo_bucket)) == sorted([s3_key_to_move, s3_key_to_leave])
+    assert sorted(s3_keys(embargo_bucket)) == sorted(
+        [s3_key_to_move, s3_key_to_leave, manifest_key]
+    )
 
     request_id = str(uuid.uuid4())
     release_files(request_id, S3_PREFIX_TO_MOVE, EMBARGO_BUCKET, PUBLISH_BUCKET)
@@ -73,7 +78,7 @@ def test_copy_files_to_publish_bucket(publish_bucket, embargo_bucket):
         S3_PREFIX_TO_MOVE, "discover-release-results.json"
     )
     assert sorted(s3_keys(publish_bucket)) == sorted(
-        [s3_key_to_move, release_results_key]
+        [s3_key_to_move, manifest_key, release_results_key]
     )
     assert sorted(s3_keys(embargo_bucket)) == sorted(
         [s3_key_to_leave, release_results_key]
@@ -86,20 +91,24 @@ def test_handle_key_without_trailing_slash(publish_bucket, embargo_bucket):
 
     embargo_bucket.upload_file(Filename=FILENAME, Key=s3_key_to_move)
     embargo_bucket.upload_file(Filename=FILENAME, Key=s3_key_to_leave)
+    manifest_key, _ = upload_manifest(embargo_bucket, S3_PREFIX_TO_MOVE, [FILENAME])
 
     assert sorted(s3_keys(publish_bucket)) == []
-    assert sorted(s3_keys(embargo_bucket)) == sorted([s3_key_to_move, s3_key_to_leave])
+    assert sorted(s3_keys(embargo_bucket)) == sorted(
+        [s3_key_to_move, s3_key_to_leave, manifest_key]
+    )
 
+    # Pass the prefix without a trailing slash; release_files should normalize it.
+    prefix_no_slash = S3_PREFIX_TO_MOVE.rstrip("/")
     request_id = str(uuid.uuid4())
-    release_files(request_id, S3_PREFIX_TO_MOVE, EMBARGO_BUCKET, PUBLISH_BUCKET)
+    release_files(request_id, prefix_no_slash, EMBARGO_BUCKET, PUBLISH_BUCKET)
 
     # VERIFY RESULTS
     release_results_key = os.path.join(
         S3_PREFIX_TO_MOVE, "discover-release-results.json"
     )
-
     assert sorted(s3_keys(publish_bucket)) == sorted(
-        [s3_key_to_move, release_results_key]
+        [s3_key_to_move, manifest_key, release_results_key]
     )
     assert sorted(s3_keys(embargo_bucket)) == sorted(
         [s3_key_to_leave, release_results_key]
@@ -117,8 +126,14 @@ def test_copy_files_pagination(publish_bucket, embargo_bucket):
     for key in s3_keys_to_leave:
         embargo_bucket.upload_file(Filename=FILENAME, Key=key)
 
+    # The manifest only needs to exist; it doesn't have to enumerate every
+    # file in S3 for the release to succeed.
+    manifest_key, _ = upload_manifest(embargo_bucket, S3_PREFIX_TO_MOVE, [])
+
     assert sorted(s3_keys(publish_bucket)) == []
-    assert sorted(s3_keys(embargo_bucket)) == sorted(s3_keys_to_move + s3_keys_to_leave)
+    assert sorted(s3_keys(embargo_bucket)) == sorted(
+        s3_keys_to_move + s3_keys_to_leave + [manifest_key]
+    )
 
     request_id = str(uuid.uuid4())
     release_files(request_id, S3_PREFIX_TO_MOVE, EMBARGO_BUCKET, PUBLISH_BUCKET)
@@ -127,8 +142,8 @@ def test_copy_files_pagination(publish_bucket, embargo_bucket):
     release_results_key = os.path.join(
         S3_PREFIX_TO_MOVE, "discover-release-results.json"
     )
-    s3_keys_to_move.append(release_results_key)
-    assert sorted(s3_keys(publish_bucket)) == sorted(s3_keys_to_move)
+    expected_in_publish = s3_keys_to_move + [manifest_key, release_results_key]
+    assert sorted(s3_keys(publish_bucket)) == sorted(expected_in_publish)
     assert sorted(s3_keys(embargo_bucket)) == sorted(
         s3_keys_to_leave + [release_results_key]
     )
@@ -140,8 +155,10 @@ def test_embargo_bucket_only_contains_release_results(publish_bucket, embargo_bu
     for key in s3_keys_to_move:
         embargo_bucket.upload_file(Filename=FILENAME, Key=key)
 
+    manifest_key, _ = upload_manifest(embargo_bucket, S3_PREFIX_TO_MOVE, [])
+
     assert sorted(s3_keys(publish_bucket)) == []
-    assert sorted(s3_keys(embargo_bucket)) == sorted(s3_keys_to_move)
+    assert sorted(s3_keys(embargo_bucket)) == sorted(s3_keys_to_move + [manifest_key])
 
     request_id = str(uuid.uuid4())
     release_files(request_id, S3_PREFIX_TO_MOVE, EMBARGO_BUCKET, PUBLISH_BUCKET)
@@ -150,15 +167,193 @@ def test_embargo_bucket_only_contains_release_results(publish_bucket, embargo_bu
     release_results_key = os.path.join(
         S3_PREFIX_TO_MOVE, "discover-release-results.json"
     )
-    s3_keys_to_move.append(release_results_key)
+    expected_in_publish = s3_keys_to_move + [manifest_key, release_results_key]
 
-    assert sorted(s3_keys(publish_bucket)) == sorted(s3_keys_to_move)
+    assert sorted(s3_keys(publish_bucket)) == sorted(expected_in_publish)
     assert sorted(s3_keys(embargo_bucket)) == [release_results_key]
 
 
-def setup_bucket(bucket_name):
+def test_manifest_is_rewritten_with_publish_bucket_values(
+    publish_bucket, embargo_bucket
+):
+    """
+    manifest.json should be rewritten so each file entry's s3VersionId points
+    at the version ID assigned by the publish bucket; entries that already
+    have a sha256 should be rewritten with the publish-bucket SHA256; the
+    manifest's own entry should not get an s3VersionId or sha256 but its
+    `size` should match the rewritten byte count.
+    """
+
+    paths_with_sha256 = ["files/ps_client.py", "files/requirements.txt"]
+    paths_without_sha256 = ["banner.jpg", "readme.md"]
+    relative_paths = paths_with_sha256 + paths_without_sha256
+
+    for rel_path in relative_paths:
+        embargo_bucket.upload_file(
+            Filename=FILENAME, Key=os.path.join(S3_PREFIX_TO_MOVE, rel_path)
+        )
+
+    manifest_key, original_manifest = upload_manifest(
+        embargo_bucket,
+        S3_PREFIX_TO_MOVE,
+        relative_paths,
+        with_sha256=paths_with_sha256,
+    )
+
+    request_id = str(uuid.uuid4())
+    release_files(request_id, S3_PREFIX_TO_MOVE, EMBARGO_BUCKET, PUBLISH_BUCKET)
+
+    # Read the manifest out of the publish bucket
+    published_body = (
+        s3_resource.Object(PUBLISH_BUCKET, manifest_key).get()["Body"].read()
+    )
+    published_manifest = json.loads(published_body)
+    by_path = {entry["path"]: entry for entry in published_manifest["files"]}
+
+    # The manifest's own entry should not carry s3VersionId or sha256...
+    assert "s3VersionId" not in by_path[MANIFEST_RELATIVE_PATH]
+    assert "sha256" not in by_path[MANIFEST_RELATIVE_PATH]
+    # ...but its `size` should match the rewritten manifest's byte count.
+    assert by_path[MANIFEST_RELATIVE_PATH]["size"] == len(published_body)
+
+    # Every referenced file should have a fresh, non-empty version ID that
+    # differs from the stale one seeded above.
+    for rel_path in relative_paths:
+        entry = by_path[rel_path]
+        assert "s3VersionId" in entry, f"{rel_path} missing s3VersionId"
+        assert entry["s3VersionId"], f"{rel_path} has empty s3VersionId"
+        assert not entry["s3VersionId"].startswith(
+            "stale-version-"
+        ), f"{rel_path} still has the stale embargo version ID"
+
+    # Files that had a sha256 in the original manifest should have a fresh,
+    # non-stale value. Files that did NOT have a sha256 should still not
+    # have one (we don't add the field if it wasn't already there).
+    for rel_path in paths_with_sha256:
+        entry = by_path[rel_path]
+        assert "sha256" in entry, f"{rel_path} should retain its sha256 field"
+        assert entry["sha256"], f"{rel_path} has empty sha256"
+        assert not entry["sha256"].startswith(
+            "stale-sha256-"
+        ), f"{rel_path} still has the stale embargo sha256"
+
+    for rel_path in paths_without_sha256:
+        assert "sha256" not in by_path[rel_path], (
+            f"{rel_path} unexpectedly gained a sha256 field"
+        )
+
+    # Fields that the rewrite is NOT supposed to touch (name, path, size,
+    # fileType, sourcePackageId, and anything else the manifest happens to
+    # carry) must come through unchanged. Compare against the original
+    # manifest entry by entry so a future refactor that rebuilds entries
+    # from scratch and drops a field will fail this test.
+    original_by_path = {entry["path"]: entry for entry in original_manifest["files"]}
+    pass_through_fields = ("name", "path", "size", "fileType", "sourcePackageId")
+    for rel_path in relative_paths:
+        original = original_by_path[rel_path]
+        updated = by_path[rel_path]
+        for field in pass_through_fields:
+            if field in original:
+                assert field in updated, (
+                    f"{rel_path}: pass-through field {field!r} was dropped"
+                )
+                assert updated[field] == original[field], (
+                    f"{rel_path}: pass-through field {field!r} changed from "
+                    f"{original[field]!r} to {updated[field]!r}"
+                )
+
+    # And the embargo bucket's copy of the manifest should be gone.
+    assert manifest_key not in s3_keys(embargo_bucket)
+
+
+def test_release_aborts_when_manifest_missing(publish_bucket, embargo_bucket):
+    """
+    When manifest.json is absent the release must abort and leave the embargo
+    bucket files in place so the operator can fix the dataset and retry.
+    """
+    s3_key = os.path.join(S3_PREFIX_TO_MOVE, FILENAME)
+    embargo_bucket.upload_file(Filename=FILENAME, Key=s3_key)
+
+    request_id = str(uuid.uuid4())
+    with pytest.raises(FileNotFoundError):
+        release_files(request_id, S3_PREFIX_TO_MOVE, EMBARGO_BUCKET, PUBLISH_BUCKET)
+
+    # The embargo file must still be there.
+    assert s3_key in s3_keys(embargo_bucket)
+
+
+def test_release_aborts_when_manifest_references_missing_file(
+    publish_bucket, embargo_bucket
+):
+    """
+    If the manifest lists a file that isn't present in the embargo bucket,
+    the release must abort and leave embargo untouched so the operator can
+    correct the dataset and retry.
+    """
+    present_key = os.path.join(S3_PREFIX_TO_MOVE, FILENAME)
+    embargo_bucket.upload_file(Filename=FILENAME, Key=present_key)
+
+    # Manifest references the uploaded file AND a file that was never uploaded.
+    missing_rel_path = "files/never_uploaded.txt"
+    manifest_key, _ = upload_manifest(
+        embargo_bucket, S3_PREFIX_TO_MOVE, [FILENAME, missing_rel_path]
+    )
+
+    request_id = str(uuid.uuid4())
+    with pytest.raises(FileNotFoundError):
+        release_files(request_id, S3_PREFIX_TO_MOVE, EMBARGO_BUCKET, PUBLISH_BUCKET)
+
+    # Embargo should still contain everything we put in it.
+    assert present_key in s3_keys(embargo_bucket)
+    assert manifest_key in s3_keys(embargo_bucket)
+
+
+def upload_manifest(embargo_bucket, prefix, file_paths, *, with_sha256=()):
+    """
+    Build and upload a minimal manifest.json under `prefix` referencing the
+    given relative file paths. `with_sha256` lists the paths that should
+    receive a (stale) sha256 field; those entries also get a
+    sourcePackageId, mimicking the production manifest format where
+    user-uploaded files carry both a sha256 and a sourcePackageId while
+    system-generated files carry neither.
+
+    Returns a (key, manifest_dict) tuple so callers can assert that
+    pass-through fields on the rewritten manifest still match the original.
+    """
+    sha256_paths = set(with_sha256)
+    files = [
+        {
+            "name": "manifest.json",
+            "path": MANIFEST_RELATIVE_PATH,
+            "size": 0,
+            "fileType": "Json",
+        }
+    ]
+    for i, rel_path in enumerate(file_paths):
+        entry = {
+            "name": os.path.basename(rel_path),
+            "path": rel_path,
+            "size": 15,
+            "fileType": "Text",
+            "s3VersionId": f"stale-version-{i}",
+        }
+        if rel_path in sha256_paths:
+            entry["sha256"] = f"stale-sha256-{i}"
+            entry["sourcePackageId"] = f"N:package:fake-package-{i}"
+        files.append(entry)
+    manifest = {"pennsieveDatasetId": 1234, "version": 1, "files": files}
+    key = os.path.join(prefix, MANIFEST_RELATIVE_PATH)
+    embargo_bucket.put_object(
+        Key=key, Body=json.dumps(manifest).encode("utf-8")
+    )
+    return key, manifest
+
+
+def setup_bucket(bucket_name, versioned):
     s3_resource.create_bucket(Bucket=bucket_name)
     bucket = s3_resource.Bucket(bucket_name)
+    if versioned:
+        bucket.Versioning().enable()
     bucket.objects.all().delete()
     return bucket
 

--- a/test.py
+++ b/test.py
@@ -27,7 +27,7 @@ PAGINATION_TEST_FILES = int(os.environ.get("PAGINATION_TEST_FILES", 1200))
 
 # Thread pool size for parallel test-setup uploads to LocalStack. Setup-only;
 # does not affect what `release_files` itself does.
-SETUP_UPLOAD_WORKERS = int(os.environ.get("SETUP_UPLOAD_WORKERS", 16))
+SETUP_UPLOAD_WORKERS = int(os.environ.get("SETUP_UPLOAD_WORKERS", 4))
 
 s3_resource = boto3.resource("s3", endpoint_url=LOCALSTACK_URL)
 
@@ -311,6 +311,8 @@ def test_release_aborts_when_manifest_references_missing_file(
     assert present_key in s3_keys(embargo_bucket)
     assert manifest_key in s3_keys(embargo_bucket)
 
+def test_set_manifest_size_edge_case():
+    pass
 
 def upload_manifest(embargo_bucket, prefix, file_paths, *, with_sha256=()):
     """

--- a/test.py
+++ b/test.py
@@ -7,7 +7,13 @@ from concurrent.futures import ThreadPoolExecutor
 import boto3
 import pytest
 
-from main import LOCALSTACK_URL, release_files, serialize_manifest, set_manifest_size
+from main import (
+    LOCALSTACK_URL,
+    MANIFEST_FILENAME,
+    release_files,
+    serialize_manifest,
+    set_manifest_size,
+)
 
 PUBLISH_BUCKET = "test-publish-bucket"
 EMBARGO_BUCKET = "test-embargo-bucket"
@@ -19,7 +25,7 @@ S3_PREFIX_TO_MOVE = "10/"
 # Prefix of an unrelated dataset that should remain untouched by the release.
 S3_PREFIX_TO_LEAVE = "100/"
 
-MANIFEST_RELATIVE_PATH = "manifest.json"
+MANIFEST_RELATIVE_PATH = MANIFEST_FILENAME
 
 # Number of objects used by the pagination test. The S3 list page size is
 # 1000, so anything > 1000 exercises pagination.
@@ -70,7 +76,9 @@ def test_copy_files_to_publish_bucket(publish_bucket, embargo_bucket):
 
     upload_dummy(embargo_bucket, s3_key_to_move)
     upload_dummy(embargo_bucket, s3_key_to_leave)
-    manifest_key, _ = upload_manifest(embargo_bucket, S3_PREFIX_TO_MOVE, [FILENAME])
+    manifest_key, _ = create_and_upload_manifest(
+        embargo_bucket, S3_PREFIX_TO_MOVE, [FILENAME]
+    )
 
     assert sorted(s3_keys(publish_bucket)) == []
     assert sorted(s3_keys(embargo_bucket)) == sorted(
@@ -99,7 +107,9 @@ def test_handle_key_without_trailing_slash(publish_bucket, embargo_bucket):
     upload_dummy(embargo_bucket, s3_key_to_move)
     upload_dummy(embargo_bucket, s3_key_to_leave)
 
-    manifest_key, _ = upload_manifest(embargo_bucket, S3_PREFIX_TO_MOVE, [FILENAME])
+    manifest_key, _ = create_and_upload_manifest(
+        embargo_bucket, S3_PREFIX_TO_MOVE, [FILENAME]
+    )
 
     assert sorted(s3_keys(publish_bucket)) == []
     assert sorted(s3_keys(embargo_bucket)) == sorted(
@@ -133,7 +143,7 @@ def test_copy_files_pagination(publish_bucket, embargo_bucket):
 
     # The manifest only needs to exist; it doesn't have to enumerate every
     # file in S3 for the release to succeed.
-    manifest_key, _ = upload_manifest(embargo_bucket, S3_PREFIX_TO_MOVE, [])
+    manifest_key, _ = create_and_upload_manifest(embargo_bucket, S3_PREFIX_TO_MOVE, [])
 
     assert sorted(s3_keys(publish_bucket)) == []
     assert sorted(s3_keys(embargo_bucket)) == sorted(
@@ -159,7 +169,7 @@ def test_embargo_bucket_only_contains_release_results(publish_bucket, embargo_bu
 
     upload_dummies(embargo_bucket, s3_keys_to_move)
 
-    manifest_key, _ = upload_manifest(embargo_bucket, S3_PREFIX_TO_MOVE, [])
+    manifest_key, _ = create_and_upload_manifest(embargo_bucket, S3_PREFIX_TO_MOVE, [])
 
     assert sorted(s3_keys(publish_bucket)) == []
     assert sorted(s3_keys(embargo_bucket)) == sorted(s3_keys_to_move + [manifest_key])
@@ -197,7 +207,7 @@ def test_manifest_is_rewritten_with_publish_bucket_values(
         [os.path.join(S3_PREFIX_TO_MOVE, rel_path) for rel_path in relative_paths],
     )
 
-    manifest_key, original_manifest = upload_manifest(
+    manifest_key, original_manifest = create_and_upload_manifest(
         embargo_bucket,
         S3_PREFIX_TO_MOVE,
         relative_paths,
@@ -212,6 +222,18 @@ def test_manifest_is_rewritten_with_publish_bucket_values(
         s3_resource.Object(PUBLISH_BUCKET, manifest_key).get()["Body"].read()
     )
     published_manifest = json.loads(published_body)
+
+    # all non-files keys should still be present and same as original.
+    for key in original_manifest:
+        if key == "files":
+            continue
+        assert key in published_manifest, f"top-level key {key!r} was dropped"
+        assert published_manifest[key] == original_manifest[key], (
+            f"top-level key {key!r} changed from "
+            f"{original_manifest[key]!r} to {published_manifest[key]!r}"
+        )
+
+    # check the files entries have been updated correctly
     by_path = {entry["path"]: entry for entry in published_manifest["files"]}
 
     # The manifest's own entry should not carry s3VersionId or sha256...
@@ -299,7 +321,7 @@ def test_release_aborts_when_manifest_references_missing_file(
 
     # Manifest references the uploaded file AND a file that was never uploaded.
     missing_rel_path = "files/never_uploaded.txt"
-    manifest_key, _ = upload_manifest(
+    manifest_key, _ = create_and_upload_manifest(
         embargo_bucket, S3_PREFIX_TO_MOVE, [FILENAME, missing_rel_path]
     )
 
@@ -308,6 +330,70 @@ def test_release_aborts_when_manifest_references_missing_file(
         release_files(request_id, S3_PREFIX_TO_MOVE, EMBARGO_BUCKET, PUBLISH_BUCKET)
 
     # Embargo should still contain everything we put in it.
+    assert present_key in s3_keys(embargo_bucket)
+    assert manifest_key in s3_keys(embargo_bucket)
+
+
+def test_release_aborts_when_manifest_file_entry_missing_path(
+    publish_bucket, embargo_bucket
+):
+    """
+    If a manifest entry is missing its `path`, the release must abort and
+    leave embargo untouched so the operator can correct the dataset.
+    """
+    present_key = os.path.join(S3_PREFIX_TO_MOVE, FILENAME)
+    upload_dummy(embargo_bucket, present_key)
+
+    manifest = create_manifest([FILENAME])
+    manifest["files"].append(
+        {
+            "name": "orphan.txt",
+            "size": 10,
+            "fileType": "Text",
+            "s3VersionId": "stale-version-pathless",
+            # deliberately no "path" key
+        }
+    )
+    manifest_key = upload_manifest(
+        embargo_bucket,
+        S3_PREFIX_TO_MOVE,
+        manifest,
+    )
+
+    request_id = str(uuid.uuid4())
+    with pytest.raises(ValueError):
+        release_files(request_id, S3_PREFIX_TO_MOVE, EMBARGO_BUCKET, PUBLISH_BUCKET)
+
+    assert present_key in s3_keys(embargo_bucket)
+    assert manifest_key in s3_keys(embargo_bucket)
+
+
+def test_release_aborts_when_manifest_self_entry_missing(
+    publish_bucket, embargo_bucket
+):
+    """
+    If a manifest is missing its own entry, the release must abort and
+    leave embargo untouched so the operator can correct the dataset.
+    """
+    present_key = os.path.join(S3_PREFIX_TO_MOVE, FILENAME)
+    upload_dummy(embargo_bucket, present_key)
+
+    manifest = create_manifest([FILENAME])
+    manifest["files"] = [
+        file_entry
+        for file_entry in manifest["files"]
+        if file_entry["path"] != MANIFEST_RELATIVE_PATH
+    ]
+    manifest_key = upload_manifest(
+        embargo_bucket,
+        S3_PREFIX_TO_MOVE,
+        manifest,
+    )
+
+    request_id = str(uuid.uuid4())
+    with pytest.raises(ValueError):
+        release_files(request_id, S3_PREFIX_TO_MOVE, EMBARGO_BUCKET, PUBLISH_BUCKET)
+
     assert present_key in s3_keys(embargo_bucket)
     assert manifest_key in s3_keys(embargo_bucket)
 
@@ -354,9 +440,9 @@ def test_set_manifest_size_matches_serialized_length_across_range():
 
     for padding_len in range(0, 1100):
         manifest = _make_padded_manifest(padding_len)
-        self_entry = manifest["files"][0]
 
-        set_manifest_size(self_entry, manifest)
+        set_manifest_size(manifest)
+        self_entry = manifest["files"][0]
 
         actual = len(serialize_manifest(manifest))
         assert self_entry["size"] == actual, (
@@ -365,16 +451,16 @@ def test_set_manifest_size_matches_serialized_length_across_range():
         )
 
 
-def upload_manifest(embargo_bucket, prefix, file_paths, *, with_sha256=()):
+def create_manifest(file_paths, *, with_sha256=()):
     """
-    Build and upload a minimal manifest.json under `prefix` referencing the
+    Build a minimal manifest.json referencing the
     given relative file paths. `with_sha256` lists the paths that should
     receive a (stale) sha256 field; those entries also get a
     sourcePackageId, mimicking the production manifest format where
     user-uploaded files carry both a sha256 and a sourcePackageId while
     system-generated files carry neither.
 
-    Returns a (key, manifest_dict) tuple so callers can assert that
+    Returns a manifest_dict so callers can assert that
     pass-through fields on the rewritten manifest still match the original.
     """
     sha256_paths = set(with_sha256)
@@ -399,8 +485,34 @@ def upload_manifest(embargo_bucket, prefix, file_paths, *, with_sha256=()):
             entry["sourcePackageId"] = f"N:package:fake-package-{i}"
         files.append(entry)
     manifest = {"pennsieveDatasetId": 1234, "version": 1, "files": files}
+    return manifest
+
+
+def upload_manifest(embargo_bucket, prefix, manifest):
+    """
+    Uploads the given manifest.json under `prefix`.
+
+    Returns the key.
+    """
     key = os.path.join(prefix, MANIFEST_RELATIVE_PATH)
     embargo_bucket.put_object(Key=key, Body=json.dumps(manifest).encode("utf-8"))
+    return key
+
+
+def create_and_upload_manifest(embargo_bucket, prefix, file_paths, *, with_sha256=()):
+    """
+    Build and upload a minimal manifest.json under `prefix` referencing the
+    given relative file paths. `with_sha256` lists the paths that should
+    receive a (stale) sha256 field; those entries also get a
+    sourcePackageId, mimicking the production manifest format where
+    user-uploaded files carry both a sha256 and a sourcePackageId while
+    system-generated files carry neither.
+
+    Returns a (key, manifest_dict) tuple so callers can assert that
+    pass-through fields on the rewritten manifest still match the original.
+    """
+    manifest = create_manifest(file_paths, with_sha256=with_sha256)
+    key = upload_manifest(embargo_bucket, prefix, manifest)
     return key, manifest
 
 

--- a/test.py
+++ b/test.py
@@ -2,6 +2,7 @@ import json
 import os
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 
 import boto3
 import pytest
@@ -18,10 +19,15 @@ S3_PREFIX_TO_MOVE = "10/"
 # Prefix of an unrelated dataset that should remain untouched by the release.
 S3_PREFIX_TO_LEAVE = "100/"
 
-# This is a dummy file
-FILENAME = "test.txt"
-
 MANIFEST_RELATIVE_PATH = "manifest.json"
+
+# Number of objects used by the pagination test. The S3 list page size is
+# 1000, so anything > 1000 exercises pagination.
+PAGINATION_TEST_FILES = int(os.environ.get("PAGINATION_TEST_FILES", 1200))
+
+# Thread pool size for parallel test-setup uploads to LocalStack. Setup-only;
+# does not affect what `release_files` itself does.
+SETUP_UPLOAD_WORKERS = int(os.environ.get("SETUP_UPLOAD_WORKERS", 16))
 
 s3_resource = boto3.resource("s3", endpoint_url=LOCALSTACK_URL)
 
@@ -62,8 +68,8 @@ def test_copy_files_to_publish_bucket(publish_bucket, embargo_bucket):
     s3_key_to_move = os.path.join(S3_PREFIX_TO_MOVE, FILENAME)
     s3_key_to_leave = os.path.join(S3_PREFIX_TO_LEAVE, FILENAME)
 
-    embargo_bucket.upload_file(Filename=FILENAME, Key=s3_key_to_move)
-    embargo_bucket.upload_file(Filename=FILENAME, Key=s3_key_to_leave)
+    upload_dummy(embargo_bucket, s3_key_to_move)
+    upload_dummy(embargo_bucket, s3_key_to_leave)
     manifest_key, _ = upload_manifest(embargo_bucket, S3_PREFIX_TO_MOVE, [FILENAME])
 
     assert sorted(s3_keys(publish_bucket)) == []
@@ -90,8 +96,9 @@ def test_handle_key_without_trailing_slash(publish_bucket, embargo_bucket):
     s3_key_to_move = os.path.join(S3_PREFIX_TO_MOVE, FILENAME)
     s3_key_to_leave = os.path.join(S3_PREFIX_TO_LEAVE, FILENAME)
 
-    embargo_bucket.upload_file(Filename=FILENAME, Key=s3_key_to_move)
-    embargo_bucket.upload_file(Filename=FILENAME, Key=s3_key_to_leave)
+    upload_dummy(embargo_bucket, s3_key_to_move)
+    upload_dummy(embargo_bucket, s3_key_to_leave)
+
     manifest_key, _ = upload_manifest(embargo_bucket, S3_PREFIX_TO_MOVE, [FILENAME])
 
     assert sorted(s3_keys(publish_bucket)) == []
@@ -121,11 +128,8 @@ def test_copy_files_pagination(publish_bucket, embargo_bucket):
     s3_keys_to_move = create_keys(S3_PREFIX_TO_MOVE, FILENAME, 1200)
     s3_keys_to_leave = [os.path.join(S3_PREFIX_TO_LEAVE, FILENAME)]
 
-    for key in s3_keys_to_move:
-        embargo_bucket.upload_file(Filename=FILENAME, Key=key)
-
-    for key in s3_keys_to_leave:
-        embargo_bucket.upload_file(Filename=FILENAME, Key=key)
+    upload_dummies(embargo_bucket, s3_keys_to_move)
+    upload_dummies(embargo_bucket, s3_keys_to_leave)
 
     # The manifest only needs to exist; it doesn't have to enumerate every
     # file in S3 for the release to succeed.
@@ -153,8 +157,7 @@ def test_copy_files_pagination(publish_bucket, embargo_bucket):
 def test_embargo_bucket_only_contains_release_results(publish_bucket, embargo_bucket):
     s3_keys_to_move = create_keys(S3_PREFIX_TO_MOVE, FILENAME, 25)
 
-    for key in s3_keys_to_move:
-        embargo_bucket.upload_file(Filename=FILENAME, Key=key)
+    upload_dummies(embargo_bucket, s3_keys_to_move)
 
     manifest_key, _ = upload_manifest(embargo_bucket, S3_PREFIX_TO_MOVE, [])
 
@@ -189,10 +192,10 @@ def test_manifest_is_rewritten_with_publish_bucket_values(
     paths_without_sha256 = ["banner.jpg", "readme.md"]
     relative_paths = paths_with_sha256 + paths_without_sha256
 
-    for rel_path in relative_paths:
-        embargo_bucket.upload_file(
-            Filename=FILENAME, Key=os.path.join(S3_PREFIX_TO_MOVE, rel_path)
-        )
+    upload_dummies(
+        embargo_bucket,
+        [os.path.join(S3_PREFIX_TO_MOVE, rel_path) for rel_path in relative_paths],
+    )
 
     manifest_key, original_manifest = upload_manifest(
         embargo_bucket,
@@ -273,7 +276,7 @@ def test_release_aborts_when_manifest_missing(publish_bucket, embargo_bucket):
     bucket files in place so the operator can fix the dataset and retry.
     """
     s3_key = os.path.join(S3_PREFIX_TO_MOVE, FILENAME)
-    embargo_bucket.upload_file(Filename=FILENAME, Key=s3_key)
+    upload_dummy(embargo_bucket, s3_key)
 
     request_id = str(uuid.uuid4())
     with pytest.raises(FileNotFoundError):
@@ -292,7 +295,7 @@ def test_release_aborts_when_manifest_references_missing_file(
     correct the dataset and retry.
     """
     present_key = os.path.join(S3_PREFIX_TO_MOVE, FILENAME)
-    embargo_bucket.upload_file(Filename=FILENAME, Key=present_key)
+    upload_dummy(embargo_bucket, present_key)
 
     # Manifest references the uploaded file AND a file that was never uploaded.
     missing_rel_path = "files/never_uploaded.txt"
@@ -346,6 +349,40 @@ def upload_manifest(embargo_bucket, prefix, file_paths, *, with_sha256=()):
     key = os.path.join(prefix, MANIFEST_RELATIVE_PATH)
     embargo_bucket.put_object(Key=key, Body=json.dumps(manifest).encode("utf-8"))
     return key, manifest
+
+
+# This is a dummy file
+FILENAME = "test.txt"
+
+# Test fixture body. Small enough that put_object is faster than upload_file
+# (which goes through the transfer manager). The actual content doesn't
+# matter for any current test.
+DUMMY_BODY = b"This is a test!\n"
+
+
+def upload_dummy(bucket, key):
+    """
+    Upload a single small object. Uses put_object rather than upload_file to
+    skip the s3transfer manager's threshold/multipart machinery, which is
+    overkill for a 16-byte payload and adds measurable per-call overhead
+    against LocalStack on Docker Desktop.
+    """
+    bucket.put_object(Key=key, Body=DUMMY_BODY)
+
+
+def upload_dummies(bucket, keys):
+    """
+    Upload many small objects in parallel. The bottleneck against LocalStack
+    on Docker Desktop is round-trip latency per request, not bandwidth or
+    CPU, so a thread pool collapses most of the wall time. Setup-only; does
+    not affect what's under test.
+    """
+    if not keys:
+        return
+    with ThreadPoolExecutor(max_workers=SETUP_UPLOAD_WORKERS) as executor:
+        # list() forces iteration so exceptions surface here rather than
+        # being silently swallowed by the executor.
+        list(executor.map(lambda k: upload_dummy(bucket, k), keys))
 
 
 def setup_bucket(bucket_name, versioned):

--- a/test.py
+++ b/test.py
@@ -54,7 +54,8 @@ def publish_bucket(setup):
 
 @pytest.fixture(scope="function")
 def embargo_bucket(setup):
-    return setup_bucket(EMBARGO_BUCKET, versioned=False)
+    # versioning is on in the pennsieve embargo buckets at least
+    return setup_bucket(EMBARGO_BUCKET, versioned=True)
 
 
 def test_copy_files_to_publish_bucket(publish_bucket, embargo_bucket):

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-This is a test!


### PR DESCRIPTION
Fixes a bug where currently the manifest created during the embargo publish is copied to the publish bucket on release. This is a problem because the S3 versionIds and sha256 values in that manifest are specific to the embargo bucket and no longer valid in the publish bucket.

PR now rewrites the manifest before copying to the publish bucket with the correct versionIds and sha256 values for all files copied. And updates the manifest's self entry `"size"` field.

Also changes the way tests upload files to Localstack for testing which seems to speed things up when running the tests locally.
