### PR TITLE
868ja00qy fix CopyResult size types

### DIFF
--- a/main.py
+++ b/main.py
@@ -131,6 +131,9 @@ class CopyRequest:
     checksum_algorithm: str
 
 
+# These objects are deserialized into Scala objects in
+# the discover-service SQS handler where all fields are
+# expected to be strings.
 @dataclass
 class CopyResult:
     source_bucket: str

--- a/main.py
+++ b/main.py
@@ -100,7 +100,7 @@ structlog.configure(
 class ObjectAttributes:
     bucket: str
     key: str
-    size: str
+    size: int
     version_id: str
     etag: str
     sha256: str
@@ -149,6 +149,23 @@ class CopyResult:
     target_etag: str
     target_sha256: str
 
+    @classmethod
+    def from_attributes(cls, source: ObjectAttributes, target: ObjectAttributes):
+        return cls(
+            source_bucket=source.bucket,
+            source_key=source.key,
+            source_size=str(source.size),
+            source_version_id=source.version_id,
+            source_etag=source.etag,
+            source_sha256=source.sha256,
+            target_bucket=target.bucket,
+            target_key=target.key,
+            target_size=str(target.size),
+            target_version_id=target.version_id,
+            target_etag=target.etag,
+            target_sha256=target.sha256,
+        )
+
 
 class FileCopier:
     def __init__(self, logger, s3, max_part_size=5 * MB):
@@ -168,7 +185,7 @@ class FileCopier:
         return ObjectAttributes(
             bucket=bucket,
             key=key,
-            size=response.get("ObjectSize", "0"),
+            size=response.get("ObjectSize", 0),
             version_id=response.get("VersionId", "none"),
             etag=response.get("ETag", "none"),
             sha256=response.get("Checksum", {}).get("ChecksumSHA256", "none"),
@@ -288,20 +305,7 @@ class FileCopier:
             request.target_bucket, request.target_key
         )
 
-        return CopyResult(
-            source_bucket=source_attributes.bucket,
-            source_key=source_attributes.key,
-            source_size=source_attributes.size,
-            source_version_id=source_attributes.version_id,
-            source_etag=source_attributes.etag,
-            source_sha256=source_attributes.sha256,
-            target_bucket=target_attributes.bucket,
-            target_key=target_attributes.key,
-            target_size=target_attributes.size,
-            target_version_id=target_attributes.version_id,
-            target_etag=target_attributes.etag,
-            target_sha256=target_attributes.sha256,
-        )
+        return CopyResult.from_attributes(source_attributes, target_attributes)
 
 
 # Configure S3 client
@@ -558,20 +562,7 @@ def release_manifest(
     source_attrs = local.file_copier.get_object_attributes(embargo_bucket, manifest_key)
     target_attrs = local.file_copier.get_object_attributes(publish_bucket, manifest_key)
 
-    return CopyResult(
-        source_bucket=source_attrs.bucket,
-        source_key=source_attrs.key,
-        source_size=source_attrs.size,
-        source_version_id=source_attrs.version_id,
-        source_etag=source_attrs.etag,
-        source_sha256=source_attrs.sha256,
-        target_bucket=target_attrs.bucket,
-        target_key=target_attrs.key,
-        target_size=target_attrs.size,
-        target_version_id=target_attrs.version_id,
-        target_etag=target_attrs.etag,
-        target_sha256=target_attrs.sha256,
-    )
+    return CopyResult.from_attributes(source_attrs, target_attrs)
 
 
 def get_file_entry_path_or_fail(file_entry):

--- a/main.py
+++ b/main.py
@@ -100,7 +100,7 @@ structlog.configure(
 class ObjectAttributes:
     bucket: str
     key: str
-    size: int
+    size: str
     version_id: str
     etag: str
     sha256: str
@@ -135,13 +135,13 @@ class CopyRequest:
 class CopyResult:
     source_bucket: str
     source_key: str
-    source_size: int
+    source_size: str
     source_version_id: str
     source_etag: str
     source_sha256: str
     target_bucket: str
     target_key: str
-    target_size: int
+    target_size: str
     target_version_id: str
     target_etag: str
     target_sha256: str
@@ -165,7 +165,7 @@ class FileCopier:
         return ObjectAttributes(
             bucket=bucket,
             key=key,
-            size=response.get("ObjectSize", 0),
+            size=response.get("ObjectSize", "0"),
             version_id=response.get("VersionId", "none"),
             etag=response.get("ETag", "none"),
             sha256=response.get("Checksum", {}).get("ChecksumSHA256", "none"),

--- a/test.py
+++ b/test.py
@@ -398,6 +398,37 @@ def test_release_aborts_when_manifest_self_entry_missing(
     assert manifest_key in s3_keys(embargo_bucket)
 
 
+def test_release_results_only_contain_string_values(publish_bucket, embargo_bucket):
+    """
+    discover-release-results.json is consumed by the Scala discover-service,
+    which deserializes each entry into a case class whose every field is a
+    String. Any non-string value (e.g. an int leaking through from
+    s3.get_object_attributes' ObjectSize) breaks Scala deserialization at
+    runtime, so guard the JSON output against type drift.
+    """
+    s3_key = os.path.join(S3_PREFIX_TO_MOVE, FILENAME)
+    upload_dummy(embargo_bucket, s3_key)
+    create_and_upload_manifest(embargo_bucket, S3_PREFIX_TO_MOVE, [FILENAME])
+
+    request_id = str(uuid.uuid4())
+    release_files(request_id, S3_PREFIX_TO_MOVE, EMBARGO_BUCKET, PUBLISH_BUCKET)
+
+    release_results_key = os.path.join(
+        S3_PREFIX_TO_MOVE, "discover-release-results.json"
+    )
+    body = s3_resource.Object(PUBLISH_BUCKET, release_results_key).get()["Body"].read()
+    results = json.loads(body)
+
+    assert results, "expected at least one CopyResult in the release results"
+    for i, record in enumerate(results):
+        assert isinstance(record, dict), f"record {i} is not a dict: {record!r}"
+        for field, value in record.items():
+            assert isinstance(value, str), (
+                f"record {i} field {field!r} is "
+                f"{type(value).__name__} ({value!r}), expected str"
+            )
+
+
 def test_set_manifest_size_matches_serialized_length_across_range():
     """
     manifest.json carries a self-referencing `size`: the byte count of the


### PR DESCRIPTION
FIxes a bug introduced in #17. 

The fields of `CopyResult` need to be strings because that is what the deserialization code in discover-service SQS handler expects. These objects are written here in the `discover-release-results.json` file and read by the SQS handler. 

Adds a test to check that each field serizied is a string.

